### PR TITLE
Pin chalk to non-compromised version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "type-check": "tsc --noEmit"
-  },  
+  },
   "collaborators": ["Charlie Kornoelje (https://www.github.com/charkour)", "Duncan Van Keulen (https://www.github.com/TheDunco)"],
   "license": "MIT",
   "dependencies": {
     "@types/node": "^20.10.5",
-    "chalk": "^5.3.0",
+    "chalk": "5.3.0",
     "commander": "^11.1.0",
     "dotenv": "16.0.1",
     "lighthouse": "9.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ dependencies:
     specifier: ^20.10.5
     version: 20.10.5
   chalk:
-    specifier: ^5.3.0
+    specifier: 5.3.0
     version: 5.3.0
   commander:
     specifier: ^11.1.0
@@ -31,9 +31,6 @@ devDependencies:
   '@types/psi':
     specifier: ^4.1.6
     version: 4.1.6
-  '@types/uuid':
-    specifier: ^9.0.7
-    version: 9.0.7
 
 packages:
 
@@ -158,10 +155,6 @@ packages:
     dependencies:
       '@types/node': 20.10.5
     dev: false
-
-  /@types/uuid@9.0.7:
-    resolution: {integrity: sha512-WUtIVRUZ9i5dYXefDEAI7sh9/O7jGvHg7Df/5O/gtH3Yabe5odI3UWopVR1qbPXQtvOxWu3mM4XxlYeZtMWF4g==}
-    dev: true
 
   /@types/yauzl@2.10.3:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}


### PR DESCRIPTION
- [Socket is aware](https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack?ck_subscriber_id=2117349255&utm_source=convertkit&utm_medium=email&utm_campaign=%E2%9A%9B%EF%B8%8F%20This%20Week%20In%20React%20#249:%20TanStack,%20Fast-Refresh,%20MDX,%20Storybook,%20nuqs,%20AI%20Elements,%20Three-Fiber%20%7C%20Expo,%20Legend%20List,%20Uniwind,%20New%20Arch,%20Rock,%20Screens,%20IAP,%20Glass,%20Sound,%20NavigationBar%20%7C%20Interop,%20Linting,%20Safari%20-%2018938093) of a supply chain attack affecting `chalk`
- Pin chalk to the current version to avoid downloading the affected 5.6.1 version
- Also includes a new try/catch I added a while ago but never committed